### PR TITLE
Made "Feedback" inherit from parent if empty

### DIFF
--- a/OSCWidgets/ToyActivity.cpp
+++ b/OSCWidgets/ToyActivity.cpp
@@ -362,7 +362,9 @@ void ToyActivityWidget::SetLabel(const QString &label)
 
 void ToyActivityWidget::Recv(const QString &path, const OSCArgument *args, size_t count)
 {
-	if(path == m_FeedbackPath)
+  
+	
+	if(path == GetFeedbackPath())
     {
 		FadeActivity *activity = static_cast<FadeActivity*>(m_Widget);
 

--- a/OSCWidgets/ToyGrid.cpp
+++ b/OSCWidgets/ToyGrid.cpp
@@ -519,7 +519,9 @@ void ToyGrid::EditWidget(ToyWidget *widget, bool toggle)
 		m_EditPanel->SetRecvPath( QString() );
 		m_EditPanel->SetRecvPathEnabled(false);
 		m_EditPanel->SetFeedbackPath( QString() );
-		m_EditPanel->SetFeedbackPathEnabled(false);		
+		m_EditPanel->SetFeedbackPathEnabled(true); //so that the children can look up to it
+		m_EditPanel->SetFeedbackPath( GetFeedbackPath() );
+		m_EditPanel->SetFeedbackPathEnabled(true);
 		m_EditPanel->SetMin( QString() );
 		m_EditPanel->SetMax( QString() );
 		m_EditPanel->SetMinMaxEnabled(false);
@@ -573,6 +575,18 @@ void ToyGrid::AddRecvWidgets(RECV_WIDGETS &recvWidgets) const
 			recvWidgets.insert( RECV_WIDGETS_PAIR(w->GetFeedbackPath(),w) );
 	}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ToyGrid::SetFeedbackPath(const QString &feedbackPath)
+{
+	if(m_FeedbackPath != feedbackPath)
+	{
+		m_FeedbackPath = feedbackPath;
+		//UpdateToolTip();
+	}
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -899,6 +913,9 @@ void ToyGrid::onWidgetEdited(ToyWidget *widget)
 
 		m_EditPanel->GetImagePath(str);
 		SetImagePath(str);
+		
+		m_EditPanel->GetFeedbackPath(str);
+		SetFeedbackPath(str);
 		
 		QColor color;
 		m_EditPanel->GetColor(color);

--- a/OSCWidgets/ToyGrid.h
+++ b/OSCWidgets/ToyGrid.h
@@ -119,6 +119,12 @@ public:
 	virtual void GetName(QString &name) const;
 	virtual void ClearLabels();
 	
+	virtual void SetFeedbackPath(const QString &feedbackPath);
+	virtual const QString& GetFeedbackPath() const {return m_FeedbackPath;}
+
+	
+
+	
 private slots:
 	void onEdit();	
 	void onEditToyWidget();
@@ -143,6 +149,9 @@ protected:
 	size_t				m_EditWidgetIndex;
 	QMenu				*m_pContextMenu;
 	bool				m_Loading;
+	
+	QString		m_FeedbackPath;
+
 	
 	virtual ToyWidget* CreateWidget() = 0;
 	virtual QSize GetDefaultWidgetSize() const {return QSize(80,80);}

--- a/OSCWidgets/ToyWidget.cpp
+++ b/OSCWidgets/ToyWidget.cpp
@@ -22,6 +22,7 @@
 #include "EditPanel.h"
 #include "Toy.h"
 #include "Utils.h"
+#include "ToyGrid.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -109,6 +110,21 @@ void ToyWidget::SetFeedbackPath(const QString &feedbackPath)
 		UpdateToolTip();
 	}
 }
+
+const QString& ToyWidget::GetFeedbackPath() const
+{
+
+	//std::cout << m_FeedbackPath << std::endl;
+	qDebug("hello world");
+	qDebug(((ToyGrid*)parent())->GetFeedbackPath().toLatin1());
+	
+	qDebug(m_FeedbackPath.toLatin1());
+
+	
+	return (m_FeedbackPath!=""?m_FeedbackPath:((ToyGrid*)parent())->GetFeedbackPath());
+
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/OSCWidgets/ToyWidget.h
+++ b/OSCWidgets/ToyWidget.h
@@ -29,6 +29,7 @@
 class EditButton;
 class OSCArgument;
 class EosLog;
+class ToyGrid;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -62,7 +63,7 @@ public:
 	virtual bool HasPath2() const {return false;}
 	virtual const QString& GetRecvPath() const {return m_RecvPath;}
 	virtual void SetRecvPath(const QString &recvPath);
-	virtual const QString& GetFeedbackPath() const {return m_FeedbackPath;}
+	virtual const QString& GetFeedbackPath() const;
 	virtual void SetFeedbackPath(const QString &feedbackPath);
 	virtual bool HasFeedbackPath() const {return false;}
 	virtual const QString& GetText() const {return m_Text;}

--- a/OSCWidgets/moc_EditPanel.cpp
+++ b/OSCWidgets/moc_EditPanel.cpp
@@ -1,0 +1,210 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'EditPanel.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "EditPanel.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'EditPanel.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_EditButton[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       1,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      11,   20,   20,   20, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_EditButton[] = {
+    "EditButton\0onTick()\0\0"
+};
+
+void EditButton::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        EditButton *_t = static_cast<EditButton *>(_o);
+        switch (_id) {
+        case 0: _t->onTick(); break;
+        default: ;
+        }
+    }
+    Q_UNUSED(_a);
+}
+
+const QMetaObjectExtraData EditButton::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject EditButton::staticMetaObject = {
+    { &QPushButton::staticMetaObject, qt_meta_stringdata_EditButton,
+      qt_meta_data_EditButton, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &EditButton::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *EditButton::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *EditButton::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_EditButton))
+        return static_cast<void*>(const_cast< EditButton*>(this));
+    return QPushButton::qt_metacast(_clname);
+}
+
+int EditButton::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QPushButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 1)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 1;
+    }
+    return _id;
+}
+static const uint qt_meta_data_EditPanel[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+      12,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       2,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      10,   19,   19,   19, 0x05,
+      20,   19,   19,   19, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      27,   46,   19,   19, 0x08,
+      52,   19,   19,   19, 0x08,
+      72,   98,   19,   19, 0x08,
+     104,  131,   19,   19, 0x08,
+     136,  131,   19,   19, 0x08,
+     164,   98,   19,   19, 0x08,
+     189,  220,   19,   19, 0x08,
+     228,  220,   19,   19, 0x08,
+     249,  220,   19,   19, 0x08,
+     274,  220,   19,   19, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_EditPanel[] = {
+    "EditPanel\0edited()\0\0done()\0"
+    "onGridChanged(int)\0value\0onEditingFinished()\0"
+    "onHiddenStateChanged(int)\0state\0"
+    "onPathTextChanged(QString)\0text\0"
+    "onPath2TextChanged(QString)\0"
+    "onLocalStateChanged(int)\0"
+    "onImagePathButtonClicked(bool)\0checked\0"
+    "onColorClicked(bool)\0onTextColorClicked(bool)\0"
+    "onDoneClicked(bool)\0"
+};
+
+void EditPanel::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        EditPanel *_t = static_cast<EditPanel *>(_o);
+        switch (_id) {
+        case 0: _t->edited(); break;
+        case 1: _t->done(); break;
+        case 2: _t->onGridChanged((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 3: _t->onEditingFinished(); break;
+        case 4: _t->onHiddenStateChanged((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 5: _t->onPathTextChanged((*reinterpret_cast< const QString(*)>(_a[1]))); break;
+        case 6: _t->onPath2TextChanged((*reinterpret_cast< const QString(*)>(_a[1]))); break;
+        case 7: _t->onLocalStateChanged((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 8: _t->onImagePathButtonClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 9: _t->onColorClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 10: _t->onTextColorClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 11: _t->onDoneClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData EditPanel::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject EditPanel::staticMetaObject = {
+    { &QWidget::staticMetaObject, qt_meta_stringdata_EditPanel,
+      qt_meta_data_EditPanel, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &EditPanel::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *EditPanel::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *EditPanel::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_EditPanel))
+        return static_cast<void*>(const_cast< EditPanel*>(this));
+    return QWidget::qt_metacast(_clname);
+}
+
+int EditPanel::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 12)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 12;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void EditPanel::edited()
+{
+    QMetaObject::activate(this, &staticMetaObject, 0, 0);
+}
+
+// SIGNAL 1
+void EditPanel::done()
+{
+    QMetaObject::activate(this, &staticMetaObject, 1, 0);
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_FadeButton.cpp
+++ b/OSCWidgets/moc_FadeButton.cpp
@@ -1,0 +1,100 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'FadeButton.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "FadeButton.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'FadeButton.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_FadeButton[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       4,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      11,   23,   23,   23, 0x08,
+      24,   23,   23,   23, 0x08,
+      37,   23,   23,   23, 0x08,
+      54,   23,   23,   23, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_FadeButton[] = {
+    "FadeButton\0onPressed()\0\0onReleased()\0"
+    "onClickTimeout()\0onHoverTimeout()\0"
+};
+
+void FadeButton::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        FadeButton *_t = static_cast<FadeButton *>(_o);
+        switch (_id) {
+        case 0: _t->onPressed(); break;
+        case 1: _t->onReleased(); break;
+        case 2: _t->onClickTimeout(); break;
+        case 3: _t->onHoverTimeout(); break;
+        default: ;
+        }
+    }
+    Q_UNUSED(_a);
+}
+
+const QMetaObjectExtraData FadeButton::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject FadeButton::staticMetaObject = {
+    { &QPushButton::staticMetaObject, qt_meta_stringdata_FadeButton,
+      qt_meta_data_FadeButton, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &FadeButton::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *FadeButton::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *FadeButton::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_FadeButton))
+        return static_cast<void*>(const_cast< FadeButton*>(this));
+    return QPushButton::qt_metacast(_clname);
+}
+
+int FadeButton::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QPushButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 4)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 4;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_MainWindow.cpp
+++ b/OSCWidgets/moc_MainWindow.cpp
@@ -1,0 +1,328 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'MainWindow.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "MainWindow.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'MainWindow.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_OpacityAction[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      14,   40,   48,   48, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      49,   65,   48,   48, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_OpacityAction[] = {
+    "OpacityAction\0triggeredWithOpacity(int)\0"
+    "opacity\0\0onToggled(bool)\0checked\0"
+};
+
+void OpacityAction::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        OpacityAction *_t = static_cast<OpacityAction *>(_o);
+        switch (_id) {
+        case 0: _t->triggeredWithOpacity((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 1: _t->onToggled((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData OpacityAction::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject OpacityAction::staticMetaObject = {
+    { &QAction::staticMetaObject, qt_meta_stringdata_OpacityAction,
+      qt_meta_data_OpacityAction, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &OpacityAction::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *OpacityAction::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *OpacityAction::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_OpacityAction))
+        return static_cast<void*>(const_cast< OpacityAction*>(this));
+    return QAction::qt_metacast(_clname);
+}
+
+int OpacityAction::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QAction::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void OpacityAction::triggeredWithOpacity(int _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_OpacityMenu[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      12,   32,   40,   40, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      41,   32,   40,   40, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_OpacityMenu[] = {
+    "OpacityMenu\0opacityChanged(int)\0opacity\0"
+    "\0onTriggeredWithOpacity(int)\0"
+};
+
+void OpacityMenu::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        OpacityMenu *_t = static_cast<OpacityMenu *>(_o);
+        switch (_id) {
+        case 0: _t->opacityChanged((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 1: _t->onTriggeredWithOpacity((*reinterpret_cast< int(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData OpacityMenu::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject OpacityMenu::staticMetaObject = {
+    { &QMenu::staticMetaObject, qt_meta_stringdata_OpacityMenu,
+      qt_meta_data_OpacityMenu, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &OpacityMenu::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *OpacityMenu::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *OpacityMenu::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_OpacityMenu))
+        return static_cast<void*>(const_cast< OpacityMenu*>(this));
+    return QMenu::qt_metacast(_clname);
+}
+
+int OpacityMenu::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QMenu::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void OpacityMenu::opacityChanged(int _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_MainWindow[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+      26,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      11,   20,   20,   20, 0x08,
+      21,   20,   20,   20, 0x08,
+      40,   20,   20,   20, 0x08,
+      60,   20,   20,   20, 0x08,
+      80,   20,   20,   20, 0x08,
+     102,   20,   20,   20, 0x08,
+     122,   20,   20,   20, 0x08,
+     141,   20,   20,   20, 0x08,
+     161,   20,   20,   20, 0x08,
+     181,   20,   20,   20, 0x08,
+     201,  227,   20,   20, 0x08,
+     229,  227,   20,   20, 0x08,
+     253,   20,   20,   20, 0x08,
+     273,  292,   20,   20, 0x08,
+     300,   20,   20,   20, 0x08,
+     320,  342,   20,   20, 0x08,
+     347,   20,   20,   20, 0x08,
+     363,   20,   20,   20, 0x08,
+     389,  434,   20,   20, 0x08,
+     446,  490,   20,   20, 0x08,
+     492,   20,   20,   20, 0x08,
+     515,   20,   20,   20, 0x08,
+     536,   20,   20,   20, 0x08,
+     568,   20,   20,   20, 0x08,
+     593,   20,   20,   20, 0x08,
+     612,  669,   20,   20, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_MainWindow[] = {
+    "MainWindow\0onTick()\0\0onNewFileClicked()\0"
+    "onOpenFileClicked()\0onSaveFileClicked()\0"
+    "onSaveAsFileClicked()\0onClearLogClicked()\0"
+    "onOpenLogClicked()\0onSettingsChanged()\0"
+    "onAdvancedClicked()\0onAdvancedChanged()\0"
+    "onMenuFramesEnabled(bool)\0b\0"
+    "onMenuAlwaysOnTop(bool)\0onMenuSnapToEdges()\0"
+    "onMenuOpacity(int)\0opacity\0"
+    "onMenuClearLabels()\0onSettingsAddToy(int)\0"
+    "type\0onToysChanged()\0onToysToggledMainWindow()\0"
+    "onToyTreeItemActivated(QTreeWidgetItem*,int)\0"
+    "item,column\0onToyTreeCustomContextMenuRequested(QPoint)\0"
+    "p\0onToyTreeItemDeleted()\0onToyTreeItemAdded()\0"
+    "onSystemTrayToggledMainWindow()\0"
+    "onSystemTrayToggleToys()\0onSystemTrayExit()\0"
+    "onSystemTrayActivated(QSystemTrayIcon::ActivationReason)\0"
+    "reason\0"
+};
+
+void MainWindow::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        MainWindow *_t = static_cast<MainWindow *>(_o);
+        switch (_id) {
+        case 0: _t->onTick(); break;
+        case 1: _t->onNewFileClicked(); break;
+        case 2: _t->onOpenFileClicked(); break;
+        case 3: _t->onSaveFileClicked(); break;
+        case 4: _t->onSaveAsFileClicked(); break;
+        case 5: _t->onClearLogClicked(); break;
+        case 6: _t->onOpenLogClicked(); break;
+        case 7: _t->onSettingsChanged(); break;
+        case 8: _t->onAdvancedClicked(); break;
+        case 9: _t->onAdvancedChanged(); break;
+        case 10: _t->onMenuFramesEnabled((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 11: _t->onMenuAlwaysOnTop((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 12: _t->onMenuSnapToEdges(); break;
+        case 13: _t->onMenuOpacity((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 14: _t->onMenuClearLabels(); break;
+        case 15: _t->onSettingsAddToy((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 16: _t->onToysChanged(); break;
+        case 17: _t->onToysToggledMainWindow(); break;
+        case 18: _t->onToyTreeItemActivated((*reinterpret_cast< QTreeWidgetItem*(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 19: _t->onToyTreeCustomContextMenuRequested((*reinterpret_cast< const QPoint(*)>(_a[1]))); break;
+        case 20: _t->onToyTreeItemDeleted(); break;
+        case 21: _t->onToyTreeItemAdded(); break;
+        case 22: _t->onSystemTrayToggledMainWindow(); break;
+        case 23: _t->onSystemTrayToggleToys(); break;
+        case 24: _t->onSystemTrayExit(); break;
+        case 25: _t->onSystemTrayActivated((*reinterpret_cast< QSystemTrayIcon::ActivationReason(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData MainWindow::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject MainWindow::staticMetaObject = {
+    { &QWidget::staticMetaObject, qt_meta_stringdata_MainWindow,
+      qt_meta_data_MainWindow, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &MainWindow::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *MainWindow::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *MainWindow::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_MainWindow))
+        return static_cast<void*>(const_cast< MainWindow*>(this));
+    return QWidget::qt_metacast(_clname);
+}
+
+int MainWindow::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 26)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 26;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_SettingsPanel.cpp
+++ b/OSCWidgets/moc_SettingsPanel.cpp
@@ -1,0 +1,288 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'SettingsPanel.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "SettingsPanel.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'SettingsPanel.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_AddToyButton[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      13,   25,   30,   30, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      31,   47,   30,   30, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_AddToyButton[] = {
+    "AddToyButton\0addToy(int)\0type\0\0"
+    "onClicked(bool)\0checked\0"
+};
+
+void AddToyButton::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        AddToyButton *_t = static_cast<AddToyButton *>(_o);
+        switch (_id) {
+        case 0: _t->addToy((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 1: _t->onClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData AddToyButton::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject AddToyButton::staticMetaObject = {
+    { &QPushButton::staticMetaObject, qt_meta_stringdata_AddToyButton,
+      qt_meta_data_AddToyButton, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &AddToyButton::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *AddToyButton::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *AddToyButton::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_AddToyButton))
+        return static_cast<void*>(const_cast< AddToyButton*>(this));
+    return QPushButton::qt_metacast(_clname);
+}
+
+int AddToyButton::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QPushButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void AddToyButton::addToy(int _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_AdvancedPanel[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       3,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      14,   24,   24,   24, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      25,   46,   24,   24, 0x08,
+      54,   46,   24,   24, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_AdvancedPanel[] = {
+    "AdvancedPanel\0changed()\0\0onApplyClicked(bool)\0"
+    "checked\0onRestoreDefaultsClicked(bool)\0"
+};
+
+void AdvancedPanel::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        AdvancedPanel *_t = static_cast<AdvancedPanel *>(_o);
+        switch (_id) {
+        case 0: _t->changed(); break;
+        case 1: _t->onApplyClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 2: _t->onRestoreDefaultsClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData AdvancedPanel::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject AdvancedPanel::staticMetaObject = {
+    { &QWidget::staticMetaObject, qt_meta_stringdata_AdvancedPanel,
+      qt_meta_data_AdvancedPanel, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &AdvancedPanel::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *AdvancedPanel::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *AdvancedPanel::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_AdvancedPanel))
+        return static_cast<void*>(const_cast< AdvancedPanel*>(this));
+    return QWidget::qt_metacast(_clname);
+}
+
+int AdvancedPanel::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 3)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 3;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void AdvancedPanel::changed()
+{
+    QMetaObject::activate(this, &staticMetaObject, 0, 0);
+}
+static const uint qt_meta_data_SettingsPanel[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       5,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       2,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      14,   24,   24,   24, 0x05,
+      25,   37,   24,   24, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      42,   61,   24,   24, 0x08,
+      67,   88,   24,   24, 0x08,
+      96,   37,   24,   24, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_SettingsPanel[] = {
+    "SettingsPanel\0changed()\0\0addToy(int)\0"
+    "type\0onModeChanged(int)\0index\0"
+    "onApplyClicked(bool)\0checked\0onAddToy(int)\0"
+};
+
+void SettingsPanel::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        SettingsPanel *_t = static_cast<SettingsPanel *>(_o);
+        switch (_id) {
+        case 0: _t->changed(); break;
+        case 1: _t->addToy((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 2: _t->onModeChanged((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 3: _t->onApplyClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 4: _t->onAddToy((*reinterpret_cast< int(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData SettingsPanel::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject SettingsPanel::staticMetaObject = {
+    { &QWidget::staticMetaObject, qt_meta_stringdata_SettingsPanel,
+      qt_meta_data_SettingsPanel, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &SettingsPanel::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *SettingsPanel::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *SettingsPanel::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_SettingsPanel))
+        return static_cast<void*>(const_cast< SettingsPanel*>(this));
+    return QWidget::qt_metacast(_clname);
+}
+
+int SettingsPanel::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 5)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 5;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void SettingsPanel::changed()
+{
+    QMetaObject::activate(this, &staticMetaObject, 0, 0);
+}
+
+// SIGNAL 1
+void SettingsPanel::addToy(int _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 1, _a);
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_Toy.cpp
+++ b/OSCWidgets/moc_Toy.cpp
@@ -1,0 +1,124 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'Toy.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "Toy.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'Toy.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_Toy[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       4,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       4,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+       4,   14,   14,   14, 0x05,
+      15,   14,   14,   14, 0x05,
+      36,   50,   14,   14, 0x05,
+      54,   14,   14,   14, 0x05,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_Toy[] = {
+    "Toy\0changed()\0\0recvWidgetsChanged()\0"
+    "closing(Toy*)\0toy\0toggleMainWindow()\0"
+};
+
+void Toy::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        Toy *_t = static_cast<Toy *>(_o);
+        switch (_id) {
+        case 0: _t->changed(); break;
+        case 1: _t->recvWidgetsChanged(); break;
+        case 2: _t->closing((*reinterpret_cast< Toy*(*)>(_a[1]))); break;
+        case 3: _t->toggleMainWindow(); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData Toy::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject Toy::staticMetaObject = {
+    { &QWidget::staticMetaObject, qt_meta_stringdata_Toy,
+      qt_meta_data_Toy, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &Toy::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *Toy::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *Toy::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_Toy))
+        return static_cast<void*>(const_cast< Toy*>(this));
+    return QWidget::qt_metacast(_clname);
+}
+
+int Toy::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 4)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 4;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void Toy::changed()
+{
+    QMetaObject::activate(this, &staticMetaObject, 0, 0);
+}
+
+// SIGNAL 1
+void Toy::recvWidgetsChanged()
+{
+    QMetaObject::activate(this, &staticMetaObject, 1, 0);
+}
+
+// SIGNAL 2
+void Toy::closing(Toy * _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 2, _a);
+}
+
+// SIGNAL 3
+void Toy::toggleMainWindow()
+{
+    QMetaObject::activate(this, &staticMetaObject, 3, 0);
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyActivity.cpp
+++ b/OSCWidgets/moc_ToyActivity.cpp
@@ -1,0 +1,93 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyActivity.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyActivity.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyActivity.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_FadeActivity[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       1,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      13,   24,   24,   24, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_FadeActivity[] = {
+    "FadeActivity\0onUpdate()\0\0"
+};
+
+void FadeActivity::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        FadeActivity *_t = static_cast<FadeActivity *>(_o);
+        switch (_id) {
+        case 0: _t->onUpdate(); break;
+        default: ;
+        }
+    }
+    Q_UNUSED(_a);
+}
+
+const QMetaObjectExtraData FadeActivity::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject FadeActivity::staticMetaObject = {
+    { &FadeButton::staticMetaObject, qt_meta_stringdata_FadeActivity,
+      qt_meta_data_FadeActivity, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &FadeActivity::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *FadeActivity::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *FadeActivity::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_FadeActivity))
+        return static_cast<void*>(const_cast< FadeActivity*>(this));
+    return FadeButton::qt_metacast(_clname);
+}
+
+int FadeActivity::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = FadeButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 1)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 1;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyButton.cpp
+++ b/OSCWidgets/moc_ToyButton.cpp
@@ -1,0 +1,192 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyButton.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyButton.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyButton.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_ToyButtonWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       4,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       2,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      16,   42,   42,   42, 0x05,
+      43,   42,   42,   42, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      70,   42,   42,   42, 0x08,
+      82,   42,   42,   42, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyButtonWidget[] = {
+    "ToyButtonWidget\0pressed(ToyButtonWidget*)\0"
+    "\0released(ToyButtonWidget*)\0onPressed()\0"
+    "onReleased()\0"
+};
+
+void ToyButtonWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyButtonWidget *_t = static_cast<ToyButtonWidget *>(_o);
+        switch (_id) {
+        case 0: _t->pressed((*reinterpret_cast< ToyButtonWidget*(*)>(_a[1]))); break;
+        case 1: _t->released((*reinterpret_cast< ToyButtonWidget*(*)>(_a[1]))); break;
+        case 2: _t->onPressed(); break;
+        case 3: _t->onReleased(); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyButtonWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyButtonWidget::staticMetaObject = {
+    { &ToyWidget::staticMetaObject, qt_meta_stringdata_ToyButtonWidget,
+      qt_meta_data_ToyButtonWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyButtonWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyButtonWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyButtonWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyButtonWidget))
+        return static_cast<void*>(const_cast< ToyButtonWidget*>(this));
+    return ToyWidget::qt_metacast(_clname);
+}
+
+int ToyButtonWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 4)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 4;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToyButtonWidget::pressed(ToyButtonWidget * _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+
+// SIGNAL 1
+void ToyButtonWidget::released(ToyButtonWidget * _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 1, _a);
+}
+static const uint qt_meta_data_ToyButtonGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      14,   42,   42,   42, 0x08,
+      43,   42,   42,   42, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyButtonGrid[] = {
+    "ToyButtonGrid\0onPressed(ToyButtonWidget*)\0"
+    "\0onReleased(ToyButtonWidget*)\0"
+};
+
+void ToyButtonGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyButtonGrid *_t = static_cast<ToyButtonGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onPressed((*reinterpret_cast< ToyButtonWidget*(*)>(_a[1]))); break;
+        case 1: _t->onReleased((*reinterpret_cast< ToyButtonWidget*(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyButtonGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyButtonGrid::staticMetaObject = {
+    { &ToyGrid::staticMetaObject, qt_meta_stringdata_ToyButtonGrid,
+      qt_meta_data_ToyButtonGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyButtonGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyButtonGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyButtonGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyButtonGrid))
+        return static_cast<void*>(const_cast< ToyButtonGrid*>(this));
+    return ToyGrid::qt_metacast(_clname);
+}
+
+int ToyButtonGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyGrid::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyCmd.cpp
+++ b/OSCWidgets/moc_ToyCmd.cpp
@@ -1,0 +1,191 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyCmd.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyCmd.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyCmd.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_ToyCmdWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       4,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      13,   33,   33,   33, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      34,   33,   33,   33, 0x08,
+      54,   33,   33,   33, 0x08,
+      72,   92,   33,   33, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyCmdWidget[] = {
+    "ToyCmdWidget\0send(ToyCmdWidget*)\0\0"
+    "onEditingFinished()\0onReturnPressed()\0"
+    "onSendClicked(bool)\0checked\0"
+};
+
+void ToyCmdWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyCmdWidget *_t = static_cast<ToyCmdWidget *>(_o);
+        switch (_id) {
+        case 0: _t->send((*reinterpret_cast< ToyCmdWidget*(*)>(_a[1]))); break;
+        case 1: _t->onEditingFinished(); break;
+        case 2: _t->onReturnPressed(); break;
+        case 3: _t->onSendClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyCmdWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyCmdWidget::staticMetaObject = {
+    { &ToyWidget::staticMetaObject, qt_meta_stringdata_ToyCmdWidget,
+      qt_meta_data_ToyCmdWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyCmdWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyCmdWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyCmdWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyCmdWidget))
+        return static_cast<void*>(const_cast< ToyCmdWidget*>(this));
+    return ToyWidget::qt_metacast(_clname);
+}
+
+int ToyCmdWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 4)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 4;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToyCmdWidget::send(ToyCmdWidget * _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyCmdGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       4,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      11,   33,   33,   33, 0x08,
+      34,   57,   33,   33, 0x08,
+      65,   33,   33,   33, 0x08,
+      84,  111,   33,   33, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyCmdGrid[] = {
+    "ToyCmdGrid\0onSend(ToyCmdWidget*)\0\0"
+    "onSendAllClicked(bool)\0checked\0"
+    "onSendAllTimeout()\0onStartupStateChanged(int)\0"
+    "state\0"
+};
+
+void ToyCmdGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyCmdGrid *_t = static_cast<ToyCmdGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onSend((*reinterpret_cast< ToyCmdWidget*(*)>(_a[1]))); break;
+        case 1: _t->onSendAllClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 2: _t->onSendAllTimeout(); break;
+        case 3: _t->onStartupStateChanged((*reinterpret_cast< int(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyCmdGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyCmdGrid::staticMetaObject = {
+    { &ToyGrid::staticMetaObject, qt_meta_stringdata_ToyCmdGrid,
+      qt_meta_data_ToyCmdGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyCmdGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyCmdGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyCmdGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyCmdGrid))
+        return static_cast<void*>(const_cast< ToyCmdGrid*>(this));
+    return ToyGrid::qt_metacast(_clname);
+}
+
+int ToyCmdGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyGrid::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 4)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 4;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyEncoder.cpp
+++ b/OSCWidgets/moc_ToyEncoder.cpp
@@ -1,0 +1,258 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyEncoder.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyEncoder.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyEncoder.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_FadeEncoder[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       1,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      12,   24,   32,   32, 0x05,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_FadeEncoder[] = {
+    "FadeEncoder\0tick(float)\0radians\0\0"
+};
+
+void FadeEncoder::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        FadeEncoder *_t = static_cast<FadeEncoder *>(_o);
+        switch (_id) {
+        case 0: _t->tick((*reinterpret_cast< float(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData FadeEncoder::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject FadeEncoder::staticMetaObject = {
+    { &FadeButton::staticMetaObject, qt_meta_stringdata_FadeEncoder,
+      qt_meta_data_FadeEncoder, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &FadeEncoder::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *FadeEncoder::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *FadeEncoder::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_FadeEncoder))
+        return static_cast<void*>(const_cast< FadeEncoder*>(this));
+    return FadeButton::qt_metacast(_clname);
+}
+
+int FadeEncoder::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = FadeButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 1)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 1;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void FadeEncoder::tick(float _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyEncoderWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      17,   47,   56,   56, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      57,   71,   56,   56, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyEncoderWidget[] = {
+    "ToyEncoderWidget\0tick(ToyEncoderWidget*,float)\0"
+    ",radians\0\0onTick(float)\0radians\0"
+};
+
+void ToyEncoderWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyEncoderWidget *_t = static_cast<ToyEncoderWidget *>(_o);
+        switch (_id) {
+        case 0: _t->tick((*reinterpret_cast< ToyEncoderWidget*(*)>(_a[1])),(*reinterpret_cast< float(*)>(_a[2]))); break;
+        case 1: _t->onTick((*reinterpret_cast< float(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyEncoderWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyEncoderWidget::staticMetaObject = {
+    { &ToyWidget::staticMetaObject, qt_meta_stringdata_ToyEncoderWidget,
+      qt_meta_data_ToyEncoderWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyEncoderWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyEncoderWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyEncoderWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyEncoderWidget))
+        return static_cast<void*>(const_cast< ToyEncoderWidget*>(this));
+    return ToyWidget::qt_metacast(_clname);
+}
+
+int ToyEncoderWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToyEncoderWidget::tick(ToyEncoderWidget * _t1, float _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyEncoderGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       1,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      15,   47,   56,   56, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyEncoderGrid[] = {
+    "ToyEncoderGrid\0onTick(ToyEncoderWidget*,float)\0"
+    ",radians\0\0"
+};
+
+void ToyEncoderGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyEncoderGrid *_t = static_cast<ToyEncoderGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onTick((*reinterpret_cast< ToyEncoderWidget*(*)>(_a[1])),(*reinterpret_cast< float(*)>(_a[2]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyEncoderGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyEncoderGrid::staticMetaObject = {
+    { &ToyGrid::staticMetaObject, qt_meta_stringdata_ToyEncoderGrid,
+      qt_meta_data_ToyEncoderGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyEncoderGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyEncoderGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyEncoderGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyEncoderGrid))
+        return static_cast<void*>(const_cast< ToyEncoderGrid*>(this));
+    return ToyGrid::qt_metacast(_clname);
+}
+
+int ToyEncoderGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyGrid::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 1)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 1;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyFlicker.cpp
+++ b/OSCWidgets/moc_ToyFlicker.cpp
@@ -1,0 +1,270 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyFlicker.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyFlicker.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyFlicker.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_FadeFlicker[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      12,   32,   38,   38, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      39,   55,   38,   38, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_FadeFlicker[] = {
+    "FadeFlicker\0valueChanged(float)\0value\0"
+    "\0onClicked(bool)\0checked\0"
+};
+
+void FadeFlicker::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        FadeFlicker *_t = static_cast<FadeFlicker *>(_o);
+        switch (_id) {
+        case 0: _t->valueChanged((*reinterpret_cast< float(*)>(_a[1]))); break;
+        case 1: _t->onClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData FadeFlicker::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject FadeFlicker::staticMetaObject = {
+    { &FadeButton::staticMetaObject, qt_meta_stringdata_FadeFlicker,
+      qt_meta_data_FadeFlicker, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &FadeFlicker::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *FadeFlicker::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *FadeFlicker::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_FadeFlicker))
+        return static_cast<void*>(const_cast< FadeFlicker*>(this));
+    return FadeButton::qt_metacast(_clname);
+}
+
+int FadeFlicker::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = FadeButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void FadeFlicker::valueChanged(float _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyFlickerWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      17,   55,   62,   62, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      63,   85,   62,   62, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyFlickerWidget[] = {
+    "ToyFlickerWidget\0valueChanged(ToyFlickerWidget*,float)\0"
+    ",value\0\0onValueChanged(float)\0value\0"
+};
+
+void ToyFlickerWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyFlickerWidget *_t = static_cast<ToyFlickerWidget *>(_o);
+        switch (_id) {
+        case 0: _t->valueChanged((*reinterpret_cast< ToyFlickerWidget*(*)>(_a[1])),(*reinterpret_cast< float(*)>(_a[2]))); break;
+        case 1: _t->onValueChanged((*reinterpret_cast< float(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyFlickerWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyFlickerWidget::staticMetaObject = {
+    { &ToyWidget::staticMetaObject, qt_meta_stringdata_ToyFlickerWidget,
+      qt_meta_data_ToyFlickerWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyFlickerWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyFlickerWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyFlickerWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyFlickerWidget))
+        return static_cast<void*>(const_cast< ToyFlickerWidget*>(this));
+    return ToyWidget::qt_metacast(_clname);
+}
+
+int ToyFlickerWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToyFlickerWidget::valueChanged(ToyFlickerWidget * _t1, float _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyFlickerGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       4,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      15,   55,   62,   62, 0x08,
+      63,   62,   62,   62, 0x08,
+      75,   95,   62,   62, 0x08,
+     103,   95,   62,   62, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyFlickerGrid[] = {
+    "ToyFlickerGrid\0onValueChanged(ToyFlickerWidget*,float)\0"
+    ",value\0\0onTimeout()\0onPlayClicked(bool)\0"
+    "checked\0onPauseClicked(bool)\0"
+};
+
+void ToyFlickerGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyFlickerGrid *_t = static_cast<ToyFlickerGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onValueChanged((*reinterpret_cast< ToyFlickerWidget*(*)>(_a[1])),(*reinterpret_cast< float(*)>(_a[2]))); break;
+        case 1: _t->onTimeout(); break;
+        case 2: _t->onPlayClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 3: _t->onPauseClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyFlickerGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyFlickerGrid::staticMetaObject = {
+    { &ToyGrid::staticMetaObject, qt_meta_stringdata_ToyFlickerGrid,
+      qt_meta_data_ToyFlickerGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyFlickerGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyFlickerGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyFlickerGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyFlickerGrid))
+        return static_cast<void*>(const_cast< ToyFlickerGrid*>(this));
+    return ToyGrid::qt_metacast(_clname);
+}
+
+int ToyFlickerGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyGrid::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 4)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 4;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyGrid.cpp
+++ b/OSCWidgets/moc_ToyGrid.cpp
@@ -1,0 +1,295 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyGrid.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyGrid.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyGrid.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_GridSizeButton[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       3,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       2,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      15,   40,   48,   48, 0x05,
+      49,   40,   48,   48, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      74,   90,   48,   48, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_GridSizeButton[] = {
+    "GridSizeButton\0hoveredGridSize(int,int)\0"
+    "col,row\0\0clickedGridSize(int,int)\0"
+    "onClicked(bool)\0checked\0"
+};
+
+void GridSizeButton::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        GridSizeButton *_t = static_cast<GridSizeButton *>(_o);
+        switch (_id) {
+        case 0: _t->hoveredGridSize((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 1: _t->clickedGridSize((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 2: _t->onClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData GridSizeButton::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject GridSizeButton::staticMetaObject = {
+    { &FadeButton::staticMetaObject, qt_meta_stringdata_GridSizeButton,
+      qt_meta_data_GridSizeButton, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &GridSizeButton::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *GridSizeButton::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *GridSizeButton::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_GridSizeButton))
+        return static_cast<void*>(const_cast< GridSizeButton*>(this));
+    return FadeButton::qt_metacast(_clname);
+}
+
+int GridSizeButton::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = FadeButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 3)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 3;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void GridSizeButton::hoveredGridSize(int _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+
+// SIGNAL 1
+void GridSizeButton::clickedGridSize(int _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 1, _a);
+}
+static const uint qt_meta_data_GridSizeMenu[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       3,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      13,   32,   37,   37, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      38,   57,   37,   37, 0x08,
+      65,   57,   37,   37, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_GridSizeMenu[] = {
+    "GridSizeMenu\0gridResized(QSize)\0size\0"
+    "\0onHovered(int,int)\0col,row\0"
+    "onClicked(int,int)\0"
+};
+
+void GridSizeMenu::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        GridSizeMenu *_t = static_cast<GridSizeMenu *>(_o);
+        switch (_id) {
+        case 0: _t->gridResized((*reinterpret_cast< const QSize(*)>(_a[1]))); break;
+        case 1: _t->onHovered((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 2: _t->onClicked((*reinterpret_cast< int(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData GridSizeMenu::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject GridSizeMenu::staticMetaObject = {
+    { &QMenu::staticMetaObject, qt_meta_stringdata_GridSizeMenu,
+      qt_meta_data_GridSizeMenu, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &GridSizeMenu::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *GridSizeMenu::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *GridSizeMenu::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_GridSizeMenu))
+        return static_cast<void*>(const_cast< GridSizeMenu*>(this));
+    return QMenu::qt_metacast(_clname);
+}
+
+int GridSizeMenu::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QMenu::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 3)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 3;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void GridSizeMenu::gridResized(const QSize & _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       9,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+       8,   17,   17,   17, 0x08,
+      18,   17,   17,   17, 0x08,
+      36,   17,   17,   17, 0x08,
+      47,   17,   17,   17, 0x08,
+      68,   95,   17,   17, 0x08,
+     102,   17,   17,   17, 0x08,
+     113,   17,   17,   17, 0x08,
+     122,  143,   17,   17, 0x08,
+     148,   17,   17,   17, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyGrid[] = {
+    "ToyGrid\0onEdit()\0\0onEditToyWidget()\0"
+    "onDelete()\0onToggleMainWindow()\0"
+    "onWidgetEdited(ToyWidget*)\0widget\0"
+    "onEdited()\0onDone()\0onGridResized(QSize)\0"
+    "size\0onClearLabels()\0"
+};
+
+void ToyGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyGrid *_t = static_cast<ToyGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onEdit(); break;
+        case 1: _t->onEditToyWidget(); break;
+        case 2: _t->onDelete(); break;
+        case 3: _t->onToggleMainWindow(); break;
+        case 4: _t->onWidgetEdited((*reinterpret_cast< ToyWidget*(*)>(_a[1]))); break;
+        case 5: _t->onEdited(); break;
+        case 6: _t->onDone(); break;
+        case 7: _t->onGridResized((*reinterpret_cast< const QSize(*)>(_a[1]))); break;
+        case 8: _t->onClearLabels(); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyGrid::staticMetaObject = {
+    { &Toy::staticMetaObject, qt_meta_stringdata_ToyGrid,
+      qt_meta_data_ToyGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyGrid))
+        return static_cast<void*>(const_cast< ToyGrid*>(this));
+    return Toy::qt_metacast(_clname);
+}
+
+int ToyGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = Toy::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 9)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 9;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyMetro.cpp
+++ b/OSCWidgets/moc_ToyMetro.cpp
@@ -1,0 +1,275 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyMetro.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyMetro.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyMetro.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_FadeMetro[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      10,   20,   24,   24, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      25,   41,   24,   24, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_FadeMetro[] = {
+    "FadeMetro\0tick(int)\0pos\0\0onClicked(bool)\0"
+    "checked\0"
+};
+
+void FadeMetro::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        FadeMetro *_t = static_cast<FadeMetro *>(_o);
+        switch (_id) {
+        case 0: _t->tick((*reinterpret_cast< int(*)>(_a[1]))); break;
+        case 1: _t->onClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData FadeMetro::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject FadeMetro::staticMetaObject = {
+    { &FadeButton::staticMetaObject, qt_meta_stringdata_FadeMetro,
+      qt_meta_data_FadeMetro, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &FadeMetro::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *FadeMetro::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *FadeMetro::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_FadeMetro))
+        return static_cast<void*>(const_cast< FadeMetro*>(this));
+    return FadeButton::qt_metacast(_clname);
+}
+
+int FadeMetro::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = FadeButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void FadeMetro::tick(int _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyMetroWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      15,   41,   46,   46, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      47,   59,   46,   46, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyMetroWidget[] = {
+    "ToyMetroWidget\0tick(ToyMetroWidget*,int)\0"
+    ",pos\0\0onTick(int)\0pos\0"
+};
+
+void ToyMetroWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyMetroWidget *_t = static_cast<ToyMetroWidget *>(_o);
+        switch (_id) {
+        case 0: _t->tick((*reinterpret_cast< ToyMetroWidget*(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 1: _t->onTick((*reinterpret_cast< int(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyMetroWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyMetroWidget::staticMetaObject = {
+    { &ToyWidget::staticMetaObject, qt_meta_stringdata_ToyMetroWidget,
+      qt_meta_data_ToyMetroWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyMetroWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyMetroWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyMetroWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyMetroWidget))
+        return static_cast<void*>(const_cast< ToyMetroWidget*>(this));
+    return ToyWidget::qt_metacast(_clname);
+}
+
+int ToyMetroWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToyMetroWidget::tick(ToyMetroWidget * _t1, int _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyMetroGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       6,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      13,   41,   46,   46, 0x08,
+      47,   46,   46,   46, 0x08,
+      59,   79,   46,   46, 0x08,
+      87,   79,   46,   46, 0x08,
+     108,   79,   46,   46, 0x08,
+     132,   79,   46,   46, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyMetroGrid[] = {
+    "ToyMetroGrid\0onTick(ToyMetroWidget*,int)\0"
+    ",pos\0\0onTimeout()\0onPlayClicked(bool)\0"
+    "checked\0onPauseClicked(bool)\0"
+    "onReCenterClicked(bool)\0onFanClicked(bool)\0"
+};
+
+void ToyMetroGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyMetroGrid *_t = static_cast<ToyMetroGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onTick((*reinterpret_cast< ToyMetroWidget*(*)>(_a[1])),(*reinterpret_cast< int(*)>(_a[2]))); break;
+        case 1: _t->onTimeout(); break;
+        case 2: _t->onPlayClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 3: _t->onPauseClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 4: _t->onReCenterClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 5: _t->onFanClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyMetroGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyMetroGrid::staticMetaObject = {
+    { &ToyGrid::staticMetaObject, qt_meta_stringdata_ToyMetroGrid,
+      qt_meta_data_ToyMetroGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyMetroGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyMetroGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyMetroGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyMetroGrid))
+        return static_cast<void*>(const_cast< ToyMetroGrid*>(this));
+    return ToyGrid::qt_metacast(_clname);
+}
+
+int ToyMetroGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyGrid::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 6)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 6;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyPedal.cpp
+++ b/OSCWidgets/moc_ToyPedal.cpp
@@ -1,0 +1,272 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyPedal.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyPedal.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyPedal.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_FadePedal[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       3,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      10,   22,   28,   28, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      29,   28,   28,   28, 0x08,
+      41,   28,   28,   28, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_FadePedal[] = {
+    "FadePedal\0tick(float)\0value\0\0onPressed()\0"
+    "onReleased()\0"
+};
+
+void FadePedal::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        FadePedal *_t = static_cast<FadePedal *>(_o);
+        switch (_id) {
+        case 0: _t->tick((*reinterpret_cast< float(*)>(_a[1]))); break;
+        case 1: _t->onPressed(); break;
+        case 2: _t->onReleased(); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData FadePedal::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject FadePedal::staticMetaObject = {
+    { &FadeButton::staticMetaObject, qt_meta_stringdata_FadePedal,
+      qt_meta_data_FadePedal, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &FadePedal::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *FadePedal::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *FadePedal::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_FadePedal))
+        return static_cast<void*>(const_cast< FadePedal*>(this));
+    return FadeButton::qt_metacast(_clname);
+}
+
+int FadePedal::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = FadeButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 3)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 3;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void FadePedal::tick(float _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyPedalWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      15,   43,   50,   50, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      51,   65,   50,   50, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyPedalWidget[] = {
+    "ToyPedalWidget\0tick(ToyPedalWidget*,float)\0"
+    ",value\0\0onTick(float)\0value\0"
+};
+
+void ToyPedalWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyPedalWidget *_t = static_cast<ToyPedalWidget *>(_o);
+        switch (_id) {
+        case 0: _t->tick((*reinterpret_cast< ToyPedalWidget*(*)>(_a[1])),(*reinterpret_cast< float(*)>(_a[2]))); break;
+        case 1: _t->onTick((*reinterpret_cast< float(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyPedalWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyPedalWidget::staticMetaObject = {
+    { &ToyWidget::staticMetaObject, qt_meta_stringdata_ToyPedalWidget,
+      qt_meta_data_ToyPedalWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyPedalWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyPedalWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyPedalWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyPedalWidget))
+        return static_cast<void*>(const_cast< ToyPedalWidget*>(this));
+    return ToyWidget::qt_metacast(_clname);
+}
+
+int ToyPedalWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToyPedalWidget::tick(ToyPedalWidget * _t1, float _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyPedalGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       4,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      13,   43,   50,   50, 0x08,
+      51,   50,   50,   50, 0x08,
+      63,   50,   50,   50, 0x08,
+      80,   50,   50,   50, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyPedalGrid[] = {
+    "ToyPedalGrid\0onTick(ToyPedalWidget*,float)\0"
+    ",value\0\0onTimeout()\0onPressPressed()\0"
+    "onPressReleased()\0"
+};
+
+void ToyPedalGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyPedalGrid *_t = static_cast<ToyPedalGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onTick((*reinterpret_cast< ToyPedalWidget*(*)>(_a[1])),(*reinterpret_cast< float(*)>(_a[2]))); break;
+        case 1: _t->onTimeout(); break;
+        case 2: _t->onPressPressed(); break;
+        case 3: _t->onPressReleased(); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyPedalGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyPedalGrid::staticMetaObject = {
+    { &ToyGrid::staticMetaObject, qt_meta_stringdata_ToyPedalGrid,
+      qt_meta_data_ToyPedalGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyPedalGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyPedalGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyPedalGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyPedalGrid))
+        return static_cast<void*>(const_cast< ToyPedalGrid*>(this));
+    return ToyGrid::qt_metacast(_clname);
+}
+
+int ToyPedalGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyGrid::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 4)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 4;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToySine.cpp
+++ b/OSCWidgets/moc_ToySine.cpp
@@ -1,0 +1,275 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToySine.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToySine.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToySine.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_FadeSine[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+       9,   21,   27,   27, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      28,   44,   27,   27, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_FadeSine[] = {
+    "FadeSine\0tick(float)\0value\0\0onClicked(bool)\0"
+    "checked\0"
+};
+
+void FadeSine::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        FadeSine *_t = static_cast<FadeSine *>(_o);
+        switch (_id) {
+        case 0: _t->tick((*reinterpret_cast< float(*)>(_a[1]))); break;
+        case 1: _t->onClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData FadeSine::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject FadeSine::staticMetaObject = {
+    { &FadeButton::staticMetaObject, qt_meta_stringdata_FadeSine,
+      qt_meta_data_FadeSine, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &FadeSine::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *FadeSine::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *FadeSine::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_FadeSine))
+        return static_cast<void*>(const_cast< FadeSine*>(this));
+    return FadeButton::qt_metacast(_clname);
+}
+
+int FadeSine::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = FadeButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void FadeSine::tick(float _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToySineWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      14,   41,   48,   48, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      49,   63,   48,   48, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToySineWidget[] = {
+    "ToySineWidget\0tick(ToySineWidget*,float)\0"
+    ",value\0\0onTick(float)\0value\0"
+};
+
+void ToySineWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToySineWidget *_t = static_cast<ToySineWidget *>(_o);
+        switch (_id) {
+        case 0: _t->tick((*reinterpret_cast< ToySineWidget*(*)>(_a[1])),(*reinterpret_cast< float(*)>(_a[2]))); break;
+        case 1: _t->onTick((*reinterpret_cast< float(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToySineWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToySineWidget::staticMetaObject = {
+    { &ToyWidget::staticMetaObject, qt_meta_stringdata_ToySineWidget,
+      qt_meta_data_ToySineWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToySineWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToySineWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToySineWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToySineWidget))
+        return static_cast<void*>(const_cast< ToySineWidget*>(this));
+    return ToyWidget::qt_metacast(_clname);
+}
+
+int ToySineWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToySineWidget::tick(ToySineWidget * _t1, float _t2)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)), const_cast<void*>(reinterpret_cast<const void*>(&_t2)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToySineGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       6,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      12,   41,   48,   48, 0x08,
+      49,   48,   48,   48, 0x08,
+      61,   81,   48,   48, 0x08,
+      89,   81,   48,   48, 0x08,
+     110,   81,   48,   48, 0x08,
+     134,   81,   48,   48, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToySineGrid[] = {
+    "ToySineGrid\0onTick(ToySineWidget*,float)\0"
+    ",value\0\0onTimeout()\0onPlayClicked(bool)\0"
+    "checked\0onPauseClicked(bool)\0"
+    "onReCenterClicked(bool)\0onFanClicked(bool)\0"
+};
+
+void ToySineGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToySineGrid *_t = static_cast<ToySineGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onTick((*reinterpret_cast< ToySineWidget*(*)>(_a[1])),(*reinterpret_cast< float(*)>(_a[2]))); break;
+        case 1: _t->onTimeout(); break;
+        case 2: _t->onPlayClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 3: _t->onPauseClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 4: _t->onReCenterClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        case 5: _t->onFanClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToySineGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToySineGrid::staticMetaObject = {
+    { &ToyGrid::staticMetaObject, qt_meta_stringdata_ToySineGrid,
+      qt_meta_data_ToySineGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToySineGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToySineGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToySineGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToySineGrid))
+        return static_cast<void*>(const_cast< ToySineGrid*>(this));
+    return ToyGrid::qt_metacast(_clname);
+}
+
+int ToySineGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyGrid::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 6)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 6;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToySlider.cpp
+++ b/OSCWidgets/moc_ToySlider.cpp
@@ -1,0 +1,263 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToySlider.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToySlider.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToySlider.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_FadeSlider[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      11,   33,   41,   41, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      42,   41,   41,   41, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_FadeSlider[] = {
+    "FadeSlider\0percentChanged(float)\0"
+    "percent\0\0onRecvTimeout()\0"
+};
+
+void FadeSlider::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        FadeSlider *_t = static_cast<FadeSlider *>(_o);
+        switch (_id) {
+        case 0: _t->percentChanged((*reinterpret_cast< float(*)>(_a[1]))); break;
+        case 1: _t->onRecvTimeout(); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData FadeSlider::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject FadeSlider::staticMetaObject = {
+    { &FadeButton::staticMetaObject, qt_meta_stringdata_FadeSlider,
+      qt_meta_data_FadeSlider, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &FadeSlider::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *FadeSlider::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *FadeSlider::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_FadeSlider))
+        return static_cast<void*>(const_cast< FadeSlider*>(this));
+    return FadeButton::qt_metacast(_clname);
+}
+
+int FadeSlider::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = FadeButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void FadeSlider::percentChanged(float _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToySliderWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      16,   49,   49,   49, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      50,   74,   49,   49, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToySliderWidget[] = {
+    "ToySliderWidget\0percentChanged(ToySliderWidget*)\0"
+    "\0onPercentChanged(float)\0percent\0"
+};
+
+void ToySliderWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToySliderWidget *_t = static_cast<ToySliderWidget *>(_o);
+        switch (_id) {
+        case 0: _t->percentChanged((*reinterpret_cast< ToySliderWidget*(*)>(_a[1]))); break;
+        case 1: _t->onPercentChanged((*reinterpret_cast< float(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToySliderWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToySliderWidget::staticMetaObject = {
+    { &ToyWidget::staticMetaObject, qt_meta_stringdata_ToySliderWidget,
+      qt_meta_data_ToySliderWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToySliderWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToySliderWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToySliderWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToySliderWidget))
+        return static_cast<void*>(const_cast< ToySliderWidget*>(this));
+    return ToyWidget::qt_metacast(_clname);
+}
+
+int ToySliderWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToySliderWidget::percentChanged(ToySliderWidget * _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToySliderGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       1,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      14,   49,   49,   49, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToySliderGrid[] = {
+    "ToySliderGrid\0onPercentChanged(ToySliderWidget*)\0"
+    "\0"
+};
+
+void ToySliderGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToySliderGrid *_t = static_cast<ToySliderGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onPercentChanged((*reinterpret_cast< ToySliderWidget*(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToySliderGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToySliderGrid::staticMetaObject = {
+    { &ToyGrid::staticMetaObject, qt_meta_stringdata_ToySliderGrid,
+      qt_meta_data_ToySliderGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToySliderGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToySliderGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToySliderGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToySliderGrid))
+        return static_cast<void*>(const_cast< ToySliderGrid*>(this));
+    return ToyGrid::qt_metacast(_clname);
+}
+
+int ToySliderGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyGrid::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 1)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 1;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyWidget.cpp
+++ b/OSCWidgets/moc_ToyWidget.cpp
@@ -1,0 +1,104 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyWidget.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyWidget.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyWidget.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_ToyWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      10,   27,   27,   27, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      28,   54,   27,   27, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyWidget[] = {
+    "ToyWidget\0edit(ToyWidget*)\0\0"
+    "onEditButtonClicked(bool)\0checked\0"
+};
+
+void ToyWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyWidget *_t = static_cast<ToyWidget *>(_o);
+        switch (_id) {
+        case 0: _t->edit((*reinterpret_cast< ToyWidget*(*)>(_a[1]))); break;
+        case 1: _t->onEditButtonClicked((*reinterpret_cast< bool(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyWidget::staticMetaObject = {
+    { &QWidget::staticMetaObject, qt_meta_stringdata_ToyWidget,
+      qt_meta_data_ToyWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyWidget))
+        return static_cast<void*>(const_cast< ToyWidget*>(this));
+    return QWidget::qt_metacast(_clname);
+}
+
+int ToyWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToyWidget::edit(ToyWidget * _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_ToyXY.cpp
+++ b/OSCWidgets/moc_ToyXY.cpp
@@ -1,0 +1,263 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'ToyXY.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "ToyXY.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'ToyXY.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_FadeXY[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+       7,   27,   31,   31, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      32,   31,   31,   31, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_FadeXY[] = {
+    "FadeXY\0posChanged(QPointF)\0pos\0\0"
+    "onRecvTimeout()\0"
+};
+
+void FadeXY::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        FadeXY *_t = static_cast<FadeXY *>(_o);
+        switch (_id) {
+        case 0: _t->posChanged((*reinterpret_cast< const QPointF(*)>(_a[1]))); break;
+        case 1: _t->onRecvTimeout(); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData FadeXY::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject FadeXY::staticMetaObject = {
+    { &FadeButton::staticMetaObject, qt_meta_stringdata_FadeXY,
+      qt_meta_data_FadeXY, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &FadeXY::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *FadeXY::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *FadeXY::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_FadeXY))
+        return static_cast<void*>(const_cast< FadeXY*>(this));
+    return FadeButton::qt_metacast(_clname);
+}
+
+int FadeXY::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = FadeButton::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void FadeXY::posChanged(const QPointF & _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyXYWidget[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       2,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       1,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+      12,   37,   37,   37, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      38,   60,   37,   37, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyXYWidget[] = {
+    "ToyXYWidget\0posChanged(ToyXYWidget*)\0"
+    "\0onPosChanged(QPointF)\0pos\0"
+};
+
+void ToyXYWidget::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyXYWidget *_t = static_cast<ToyXYWidget *>(_o);
+        switch (_id) {
+        case 0: _t->posChanged((*reinterpret_cast< ToyXYWidget*(*)>(_a[1]))); break;
+        case 1: _t->onPosChanged((*reinterpret_cast< const QPointF(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyXYWidget::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyXYWidget::staticMetaObject = {
+    { &ToyWidget::staticMetaObject, qt_meta_stringdata_ToyXYWidget,
+      qt_meta_data_ToyXYWidget, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyXYWidget::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyXYWidget::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyXYWidget::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyXYWidget))
+        return static_cast<void*>(const_cast< ToyXYWidget*>(this));
+    return ToyWidget::qt_metacast(_clname);
+}
+
+int ToyXYWidget::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyWidget::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 2)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 2;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void ToyXYWidget::posChanged(ToyXYWidget * _t1)
+{
+    void *_a[] = { 0, const_cast<void*>(reinterpret_cast<const void*>(&_t1)) };
+    QMetaObject::activate(this, &staticMetaObject, 0, _a);
+}
+static const uint qt_meta_data_ToyXYGrid[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       1,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       0,       // signalCount
+
+ // slots: signature, parameters, type, tag, flags
+      10,   37,   37,   37, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_ToyXYGrid[] = {
+    "ToyXYGrid\0onPosChanged(ToyXYWidget*)\0"
+    "\0"
+};
+
+void ToyXYGrid::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        ToyXYGrid *_t = static_cast<ToyXYGrid *>(_o);
+        switch (_id) {
+        case 0: _t->onPosChanged((*reinterpret_cast< ToyXYWidget*(*)>(_a[1]))); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData ToyXYGrid::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject ToyXYGrid::staticMetaObject = {
+    { &ToyGrid::staticMetaObject, qt_meta_stringdata_ToyXYGrid,
+      qt_meta_data_ToyXYGrid, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &ToyXYGrid::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *ToyXYGrid::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *ToyXYGrid::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_ToyXYGrid))
+        return static_cast<void*>(const_cast< ToyXYGrid*>(this));
+    return ToyGrid::qt_metacast(_clname);
+}
+
+int ToyXYGrid::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = ToyGrid::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 1)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 1;
+    }
+    return _id;
+}
+QT_END_MOC_NAMESPACE

--- a/OSCWidgets/moc_Toys.cpp
+++ b/OSCWidgets/moc_Toys.cpp
@@ -1,0 +1,118 @@
+/****************************************************************************
+** Meta object code from reading C++ file 'Toys.h'
+**
+** Created by: The Qt Meta Object Compiler version 63 (Qt 4.8.7)
+**
+** WARNING! All changes made in this file will be lost!
+*****************************************************************************/
+
+#include "Toys.h"
+#if !defined(Q_MOC_OUTPUT_REVISION)
+#error "The header file 'Toys.h' doesn't include <QObject>."
+#elif Q_MOC_OUTPUT_REVISION != 63
+#error "This file was generated using the moc from 4.8.7. It"
+#error "cannot be used with the include files from this version of Qt."
+#error "(The moc has changed too much.)"
+#endif
+
+QT_BEGIN_MOC_NAMESPACE
+static const uint qt_meta_data_Toys[] = {
+
+ // content:
+       6,       // revision
+       0,       // classname
+       0,    0, // classinfo
+       6,   14, // methods
+       0,    0, // properties
+       0,    0, // enums/sets
+       0,    0, // constructors
+       0,       // flags
+       2,       // signalCount
+
+ // signals: signature, parameters, type, tag, flags
+       5,   15,   15,   15, 0x05,
+      16,   15,   15,   15, 0x05,
+
+ // slots: signature, parameters, type, tag, flags
+      35,   15,   15,   15, 0x08,
+      58,   77,   15,   15, 0x08,
+      81,   15,   15,   15, 0x08,
+      96,   15,   15,   15, 0x08,
+
+       0        // eod
+};
+
+static const char qt_meta_stringdata_Toys[] = {
+    "Toys\0changed()\0\0toggleMainWindow()\0"
+    "onRecvWidgetsChanged()\0onToyClosing(Toy*)\0"
+    "toy\0onToyChanged()\0onToyToggledMainWindow()\0"
+};
+
+void Toys::qt_static_metacall(QObject *_o, QMetaObject::Call _c, int _id, void **_a)
+{
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        Q_ASSERT(staticMetaObject.cast(_o));
+        Toys *_t = static_cast<Toys *>(_o);
+        switch (_id) {
+        case 0: _t->changed(); break;
+        case 1: _t->toggleMainWindow(); break;
+        case 2: _t->onRecvWidgetsChanged(); break;
+        case 3: _t->onToyClosing((*reinterpret_cast< Toy*(*)>(_a[1]))); break;
+        case 4: _t->onToyChanged(); break;
+        case 5: _t->onToyToggledMainWindow(); break;
+        default: ;
+        }
+    }
+}
+
+const QMetaObjectExtraData Toys::staticMetaObjectExtraData = {
+    0,  qt_static_metacall 
+};
+
+const QMetaObject Toys::staticMetaObject = {
+    { &QObject::staticMetaObject, qt_meta_stringdata_Toys,
+      qt_meta_data_Toys, &staticMetaObjectExtraData }
+};
+
+#ifdef Q_NO_DATA_RELOCATION
+const QMetaObject &Toys::getStaticMetaObject() { return staticMetaObject; }
+#endif //Q_NO_DATA_RELOCATION
+
+const QMetaObject *Toys::metaObject() const
+{
+    return QObject::d_ptr->metaObject ? QObject::d_ptr->metaObject : &staticMetaObject;
+}
+
+void *Toys::qt_metacast(const char *_clname)
+{
+    if (!_clname) return 0;
+    if (!strcmp(_clname, qt_meta_stringdata_Toys))
+        return static_cast<void*>(const_cast< Toys*>(this));
+    return QObject::qt_metacast(_clname);
+}
+
+int Toys::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
+{
+    _id = QObject::qt_metacall(_c, _id, _a);
+    if (_id < 0)
+        return _id;
+    if (_c == QMetaObject::InvokeMetaMethod) {
+        if (_id < 6)
+            qt_static_metacall(this, _c, _id, _a);
+        _id -= 6;
+    }
+    return _id;
+}
+
+// SIGNAL 0
+void Toys::changed()
+{
+    QMetaObject::activate(this, &staticMetaObject, 0, 0);
+}
+
+// SIGNAL 1
+void Toys::toggleMainWindow()
+{
+    QMetaObject::activate(this, &staticMetaObject, 1, 0);
+}
+QT_END_MOC_NAMESPACE


### PR DESCRIPTION
Not fully there but shows the principle..

Only does the FeedbackPath for now, basically if that’s empty then it pulls the value from the Grid (which is now enabled). Couple of issues though..

- Haven’t looked at persistence
- Probably need to split the Getter on feedbackPath() so that it doesn’t change the local value when editPanel is loaded (as that also calls GetFeedbackPath()
- Haven’t looked at wildcards yet, but am thinking that you could have %c = column, %r = row, %n = cell number